### PR TITLE
Add info about `delimiter` tag to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ type config struct {
 	Secret            []byte        `env:"SECRET" required:"true"`
 	Region            string        `env:"REGION"`
 	Port              int           `env:"PORT" required:"true"`
-	Peers             []string      `env:"PEERS"`
+	Peers             []string      `env:"PEERS"` // you can use `delimiter` tag to specify separator, for example `delimiter:" "` 
 	ConnectionTimeout time.Duration `env:"TIMEOUT" default:"10s"`
 }
 


### PR DESCRIPTION
I've learned about it only after digging into code, I think it's useful to show it upfront.