### PR TITLE
feat: allow fetching env from a prefix

### DIFF
--- a/env.go
+++ b/env.go
@@ -24,6 +24,13 @@ type Setter interface {
 // If a field is unexported or required configuration is not
 // found, an error will be returned.
 func Set(i interface{}) (err error) {
+	return SetPrefix(i, "")
+}
+
+// SetPrefix sets the fields of a struct from environment config
+// with a given prefix. If a field is unexported or required
+// configuration is not found, an error will be returned.
+func SetPrefix(i interface{}, prefix string) (err error) {
 	v := reflect.ValueOf(i)
 
 	// Don't try to process a non-pointer value.
@@ -35,7 +42,7 @@ func Set(i interface{}) (err error) {
 	t := reflect.TypeOf(i).Elem()
 
 	for i := 0; i < t.NumField(); i++ {
-		if err = processField(t.Field(i), v.Field(i)); err != nil {
+		if err = processField(prefix, t.Field(i), v.Field(i)); err != nil {
 			return
 		}
 	}
@@ -47,7 +54,7 @@ func Set(i interface{}) (err error) {
 // and attempt to set it.  If not found, another check for the
 // "required" tag will be performed to decided whether an error
 // needs to be returned.
-func processField(t reflect.StructField, v reflect.Value) (err error) {
+func processField(prefix string, t reflect.StructField, v reflect.Value) (err error) {
 	envTag, ok := t.Tag.Lookup("env")
 	if !ok {
 		return
@@ -61,7 +68,7 @@ func processField(t reflect.StructField, v reflect.Value) (err error) {
 
 	// Lookup the environment variable and if found, set and
 	// return
-	env, ok := os.LookupEnv(envTag)
+	env, ok := os.LookupEnv(prefix + envTag)
 	if ok {
 		return setField(t, v, env)
 	}

--- a/env_test.go
+++ b/env_test.go
@@ -614,7 +614,7 @@ func TestInvalidConfigurationForDuration(t *testing.T) {
 
 	err := Set(&config)
 	ErrorNotNil(t, err)
-	Equals(t, `error setting "Prop": time: unknown unit hh in duration 1hh`, err.Error())
+	Equals(t, `error setting "Prop": time: unknown unit "hh" in duration "1hh"`, err.Error())
 }
 
 func TestEnvNonPointer(t *testing.T) {
@@ -662,6 +662,17 @@ func TestEnvCustomTypeStructWithError(t *testing.T) {
 	ErrorNotNil(t, err)
 	Assert(t, strings.HasPrefix(err.Error(), "error in custom setter"))
 	Assert(t, strings.Contains(err.Error(), errConfigDurationError.Error()))
+}
+
+func TestEnvPrefixed(t *testing.T) {
+	os.Setenv("PROP_PROP", "hello")
+
+	config := struct {
+		Prop string `env:"PROP"`
+	}{}
+
+	ErrorNil(t, SetPrefix(&config, "PROP_"))
+	Equals(t, "hello", config.Prop)
 }
 
 type configDuration struct {


### PR DESCRIPTION
Hello, I love how simple the interface of this library is, the only thing I find missing is the ability to include a prefix in the lookup. This would allow reusable structs with different environment "namespaces".

Resolves #7 